### PR TITLE
Fix sensor name in import-blinis

### DIFF
--- a/cli_li3ds/import_blinis.py
+++ b/cli_li3ds/import_blinis.py
@@ -87,10 +87,10 @@ class ImportBlinis(Command):
 
         metadata = {
             'basename': os.path.basename(filename),
-            'KeyIm2TimeCam': xmlutil.findtext(root, 'KeyIm2TimeCam'),
+            'sensor_name': xmlutil.findtext(root, 'KeyIm2TimeCam'),
         }
 
-        sensor = {'type': 'group'}
+        sensor = {'name': '{sensor_name}', 'type': 'group'}
         referential = {'name': 'base'}
         transfotree = {}
         api.update_obj(args, metadata, sensor, 'sensor')


### PR DESCRIPTION
Before this commit the sensor name was set to the blinis file name. With this commit it is set to the text in the KeyIm2TimeCam node of the blinis file.