### PR TITLE
Add --filename-pattern argument to import-autocal

### DIFF
--- a/cli_li3ds/api.py
+++ b/cli_li3ds/api.py
@@ -531,7 +531,7 @@ def update_obj(args, metadata, obj, type_):
         obj.setdefault('name', '{basename}')
     if all(not type_.startswith(s) for s in nodesc):
         obj.setdefault('description', 'Imported from "{basename}"')
-    if type_ in args:
+    if args and type_ in args:
         obj.update({k: v for k, v in args[type_].items() if v})
     metadata_no_none = {k: v for k, v in metadata.items() if v is not None}
     for key in list(obj.keys()):

--- a/cli_li3ds/import_extcalib.py
+++ b/cli_li3ds/import_extcalib.py
@@ -95,28 +95,35 @@ class ImportExtCalib(Command):
             'basename': os.path.basename(filename),
         }
 
-        sensor = {'type': 'group'}
-        referential = {'name': 'base'}
+        sensor_group = {'type': 'group'}
+        referential_base = {'name': 'base'}
         transfotree = {}
-        api.update_obj(args, metadata, sensor, 'sensor')
-        api.update_obj(args, metadata, referential, 'referential')
+
+        api.update_obj(args, metadata, sensor_group, 'sensor')
+        api.update_obj(args, metadata, referential_base, 'referential')
         api.update_obj(args, metadata, transfotree, 'transfotree')
 
-        sensor = api.Sensor(sensor)
-        base = api.Referential(sensor, referential)
+        sensor_group = api.Sensor(sensor_group)
+        referential_base = api.Referential(sensor_group, referential_base)
 
         transfos = []
         for camera in cameras:
             metadata['IdGrp'] = camera['id']
+
+            sensor = {'name': '{IdGrp}', 'type': 'camera'}
             referential = {'name': '{IdGrp}'}
             transfo = {'name': '{IdGrp}'}
-            api.update_obj(args, metadata, referential, 'referential')
-            api.update_obj(args, metadata, transfo, 'transfo')
+
+            api.update_obj(None, metadata, sensor, 'sensor')
+            api.update_obj(None, metadata, referential, 'referential')
+            api.update_obj(None, metadata, transfo, 'transfo')
+
+            sensor = api.Sensor(sensor)
             referential = api.Referential(sensor, referential)
-            transfo = transfo_grp_json(base, referential, transfo, camera)
+            transfo = transfo_grp_json(referential_base, referential, transfo, camera)
             transfos.append(transfo)
 
-        transfotree = api.Transfotree(transfos, sensor, transfotree)
+        transfotree = api.Transfotree(transfos, sensor_group, transfotree)
         objs.add(transfotree)
 
     @staticmethod
@@ -129,28 +136,35 @@ class ImportExtCalib(Command):
             'sensor_name': xmlutil.findtext(root, 'KeyIm2TimeCam'),
         }
 
-        sensor = {'name': '{sensor_name}', 'type': 'group'}
-        referential = {'name': 'base'}
+        sensor_group = {'name': '{sensor_name}', 'type': 'group'}
+        referential_base = {'name': 'base'}
         transfotree = {}
-        api.update_obj(args, metadata, sensor, 'sensor')
-        api.update_obj(args, metadata, referential, 'referential')
+
+        api.update_obj(args, metadata, sensor_group, 'sensor')
+        api.update_obj(args, metadata, referential_base, 'referential')
         api.update_obj(args, metadata, transfotree, 'transfotree')
 
-        sensor = api.Sensor(sensor)
-        base = api.Referential(sensor, referential)
+        sensor_group = api.Sensor(sensor_group)
+        referential_base = api.Referential(sensor_group, referential_base)
 
         transfos = []
         for node in nodes:
             metadata['IdGrp'] = xmlutil.findtext(node, 'IdGrp')
+
+            sensor = {'name': '{IdGrp}', 'type': 'camera'}
             referential = {'name': '{IdGrp}'}
             transfo = {'name': '{IdGrp}'}
-            api.update_obj(args, metadata, referential, 'referential')
-            api.update_obj(args, metadata, transfo, 'transfo')
+
+            api.update_obj(None, metadata, sensor, 'sensor')
+            api.update_obj(None, metadata, referential, 'referential')
+            api.update_obj(None, metadata, transfo, 'transfo')
+
+            sensor = api.Sensor(sensor)
             referential = api.Referential(sensor, referential)
-            transfo = transfo_grp_xml(base, referential, transfo, node)
+            transfo = transfo_grp_xml(referential_base, referential, transfo, node)
             transfos.append(transfo)
 
-        transfotree = api.Transfotree(transfos, sensor, transfotree)
+        transfotree = api.Transfotree(transfos, sensor_group, transfotree)
         objs.add(transfotree)
 
 

--- a/cli_li3ds/import_ori.py
+++ b/cli_li3ds/import_ori.py
@@ -108,7 +108,7 @@ class ImportOri(Command):
         xmlutil.child_check(node, 'ConvOri/KnownConv', 'eConvApero_DistM2C')
         xmlutil.child_check(node, 'TypeProj', 'eProjStenope')
 
-        intrinsics = ImportAutocal.handle_autocal(objs, args, filename, node)
+        intrinsics = ImportAutocal.handle_autocal(objs, args, filename, None, node)
         sensor, transfotree, camera_ref, image_ref = intrinsics
 
         world = api.Referential(sensor, referential, name='world')

--- a/test.sh
+++ b/test.sh
@@ -23,10 +23,7 @@ fi
 
 set -x #echo on
 
-li3ds import-autocal  $li3dsARGS $@ data/AutoCal_Foc-12000_Cam-Caml024_20161205a.xml
-li3ds import-autocal  $li3dsARGS $@ data/AutoCal_Foc-12000_Cam-Caml025_20161205a.xml
-li3ds import-autocal  $li3dsARGS $@ data/AutoCal_Foc-15000_Cam-Caml023_20161205a.xml
-li3ds import-autocal  $li3dsARGS $@ data/AutoCal_Foc-15000_Cam-Caml026_20161205a.xml
+li3ds import-autocal  $li3dsARGS $@ -p 'AutoCal_Foc-1[25]000_Cam-Caml(?P<sensor_name>\d+)_20161205a.xml' data/AutoCal_Foc-*_Cam-Caml*_20161205a.xml
 li3ds import-autocal  $li3dsARGS $@ data/Calib-00.xml
 li3ds import-autocal  $li3dsARGS $@ data/Calib-1.xml
 li3ds import-autocal  $li3dsARGS $@ data/CalibFrancesco.xml


### PR DESCRIPTION
This PR does two things:

- add a `--filename-pattern` argument to `import-autocal`
- change `import-extcalib` to attach camera referentials to camera sensors instead of sensor group
