### PR TITLE
Make import_image parse image width/height as floats

### DIFF
--- a/cli_li3ds/import_image.py
+++ b/cli_li3ds/import_image.py
@@ -24,7 +24,7 @@ class ImportImage(Command):
         api.add_arguments(parser)
         parser.add_argument(
             '--image-size', '-z',
-            nargs=2, type=int,
+            nargs=2, type=float,
             help='image size (e.g. "1200 600") (optional)')
         parser.add_argument(
             '--image-dir', '-f',


### PR DESCRIPTION
This is for consistency with what import-autocal and import-orimatis use.