### PR TITLE
Add import-trajectory command

### DIFF
--- a/cli_li3ds/api.py
+++ b/cli_li3ds/api.py
@@ -84,6 +84,8 @@ class ApiServer(object):
                 'session': [],
                 'datasource': [],
                 'platforms/{id}/config': [],
+                'foreignpc/server': [],
+                'foreignpc/table': [],
             }
 
     @handle_connection_errors
@@ -570,9 +572,29 @@ class Config(ApiObj):
         self.parent = platform
 
 
+class ForeignpcServer(ApiObj):
+    type_ = 'foreignpc/server'
+    key = ('name',)
+
+    def __init__(self, obj=None, **kwarg):
+        keys = ('id', 'name', 'driver', 'options')
+        super().__init__(keys, obj, **kwarg)
+
+
+class ForeignpcTable(ApiObj):
+    type_ = 'foreignpc/table'
+    key = ('table',)
+
+    def __init__(self, server, obj=None, **kwarg):
+        keys = ('table', 'srid', 'options')
+        super().__init__(keys, obj, **kwarg)
+        self.objs = {'server': server}
+
+
 def update_obj(args, metadata, obj, type_):
-    noname = ('datasource',)
-    nodesc = ('datasource', 'transfotree', 'project', 'session')
+    noname = ('datasource', 'foreignpc/table')
+    nodesc = ('datasource', 'transfotree', 'project', 'session',
+              'foreignpc/server', 'foreignpc/table')
     if all(not type_.startswith(s) for s in noname):
         obj.setdefault('name', '{basename}')
     if all(not type_.startswith(s) for s in nodesc):

--- a/cli_li3ds/import_trajectory.py
+++ b/cli_li3ds/import_trajectory.py
@@ -1,0 +1,118 @@
+import logging
+import pathlib
+import re
+
+from cliff.command import Command
+
+from . import api
+
+
+class ImportTrajectory(Command):
+    """ import one or several trajectories
+    """
+
+    log = logging.getLogger(__name__)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_parser(self, prog_name):
+        self.log.debug(prog_name)
+        parser = super().get_parser(prog_name)
+        api.add_arguments(parser)
+        parser.add_argument(
+            '--server-name', '-n',
+            default='sbet',
+            help='name of foreign server to create (optional, default is "sbet")')
+        parser.add_argument(
+            '--database-schema', '-s',
+            help='name of database schema into which foreign tables are created '
+                 '(optional, default is "public")',
+            default='public')
+        parser.add_argument(
+            '--srid', '-r',
+            type=int, default=4326,
+            help='SRID of trajectory coordinates (optional, default is 4326)')
+        parser.add_argument(
+            '--trajectory-dir', '-f',
+            type=pathlib.Path, default='.',
+            help='base directory to search for trajectories (optional, default is ".")')
+        parser.add_argument(
+            '--filename-pattern', '-p',
+            help='file name pattern')
+        parser.add_argument(
+            'filename', nargs='+',
+            help='trajectory file names, may be Unix-style patterns (e.g. *.sbet)')
+        return parser
+
+    def take_action(self, parsed_args):
+        server = api.ApiServer(parsed_args, self.log)
+        objs = api.ApiObjs(server)
+
+        args = {
+            'foreignpc/table': {
+                'schema': parsed_args.database_schema,
+                'srid': parsed_args.srid,
+            },
+            'foreignpc/server': {
+                'name': parsed_args.server_name,
+            },
+        }
+
+        for trajectory_path in self.matching_filenames(parsed_args):
+            self.log.info('Importing {}'.format(
+                trajectory_path.relative_to(parsed_args.trajectory_dir)))
+            self.handle_trajectory(objs, args, parsed_args.trajectory_dir, trajectory_path)
+
+        objs.get_or_create()
+        self.log.info('Success!\n')
+
+    @staticmethod
+    def matching_filenames(parsed_args):
+        for filename in parsed_args.filename:
+            for trajectory_path in parsed_args.trajectory_dir.rglob(filename):
+                if parsed_args.filename_pattern:
+                    match = re.match(parsed_args.filename_pattern, trajectory_path.name)
+                else:
+                    match = True
+                if match:
+                    yield trajectory_path
+
+    @staticmethod
+    def handle_trajectory(objs, args, trajectory_dir, trajectory_path):
+
+        metadata = {
+            'table': trajectory_path.name.split('.')[0],
+            'trajectory': str(trajectory_path),
+        }
+
+        foreignpc_server = {
+            'driver': 'fdwli3ds.Sbet',
+            'options': {},
+        }
+        foreignpc_table = {
+            'table': '{table}',
+            'trajectory': '{trajectory}',
+        }
+
+        api.update_obj(args, metadata, foreignpc_server, 'foreignpc/server')
+        api.update_obj(args, metadata, foreignpc_table, 'foreignpc/table')
+
+        foreignpc_server = api.ForeignpcServer(foreignpc_server)
+        foreignpc_table = create_foreignpc_table(foreignpc_table, foreignpc_server, trajectory_path)
+
+        objs.add(foreignpc_table)
+
+
+def create_foreignpc_table(foreignpc_table, foreignpc_server, trajectory_path):
+    table = '{schema}.{table}'.format(**foreignpc_table)
+    del foreignpc_table['schema']
+    del foreignpc_table['table']
+
+    options = {
+        'sources': foreignpc_table['trajectory'],
+        'patch_size': 100,
+    }
+    del foreignpc_table['trajectory']
+
+    return api.ForeignpcTable(foreignpc_server, foreignpc_table, table=table, options=options)

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
             'import-ori = cli_li3ds.import_ori:ImportOri',
             'import-orimatis = cli_li3ds.import_orimatis:ImportOrimatis',
             'import-image = cli_li3ds.import_image:ImportImage',
+            'import-trajectory = cli_li3ds.import_trajectory:ImportTrajectory',
         ]
     }
 )


### PR DESCRIPTION
This adds an `import-trajectory` command. This command uses the API's `foreignpc/server` and `foreignpc/table` entrypoints to create foreign servers and tables for the provided trajectories.

At this point no datasource is created. The `import-trajectory` command will need to be extended for that.

Requires https://github.com/LI3DS/api-li3ds/pull/43.