### PR TITLE
import-ept: create lidar sensor with no specs

### DIFF
--- a/cli_li3ds/import_ept.py
+++ b/cli_li3ds/import_ept.py
@@ -148,7 +148,7 @@ class ImportEpt(Command):
         foreignpc_view = create_foreignpc_view(foreignpc_view, foreignpc_table)
         objs.add(foreignpc_view)
 
-        sensor = api.Sensor(sensor, specifications={})
+        sensor = api.Sensor(sensor)
         project = api.Project(project)
         platform = api.Platform(platform)
         session = api.Session(project, platform, session)


### PR DESCRIPTION
import-platform and import-ept should create the "lidar" sensor in the same way.