### PR TITLE
func_signature defines the order of function args

### DIFF
--- a/cli_li3ds/api.py
+++ b/cli_li3ds/api.py
@@ -428,12 +428,6 @@ class TransfoType(ApiObj):
         keys = ('id', 'name', 'description', 'func_signature')
         super().__init__(keys, obj, **kwarg)
 
-    def update(self, **kwarg):
-        func_signature = kwarg.get('func_signature')
-        if func_signature:
-            kwarg['func_signature'] = sorted(func_signature)
-        return super().update(**kwarg)
-
 
 class Transfo(ApiObj):
     type_ = 'transfo'
@@ -453,14 +447,9 @@ class Transfo(ApiObj):
         super().__init__(keys, obj, **kwarg)
 
         if transfo_type is noobj:
-            if not func_signature:
-                parameters = self.obj.get('parameters')
-                if parameters:
-                    func_signature = list(parameters[0].keys())
-                    if '_time' not in func_signature:
-                        func_signature.append('_time')
-                else:
-                    func_signature = ['_time']
+            assert(func_signature is not None)
+            if '_time' not in func_signature:
+                func_signature.append('_time')
             transfo_type = TransfoType(
                 id=type_id,
                 name=type_name,

--- a/cli_li3ds/distortion.py
+++ b/cli_li3ds/distortion.py
@@ -90,7 +90,7 @@ def poly_deg_data_reader(node, i):
         'C': states[1:3],
         'p': params,
     }
-    return type_, parameters
+    return type_, parameters, ['S', 'C', 'p']
 
 
 @_register('eModeleEbner')
@@ -102,7 +102,7 @@ def ebner_data_reader(node, i=0):
     :param node: the ``ModUnif`` XML node.
     """
     states, params = _read_parameters(node, 1, 12)
-    return 'poly_ebner', {'B': states[0], 'p': params}
+    return 'poly_ebner', {'B': states[0], 'p': params}, ['B', 'p']
 
 
 @_register('eModeleDCBrown')
@@ -114,7 +114,7 @@ def d_c_brown_data_reader(node, i=0):
     :param node: the ``ModUnif`` XML node.
     """
     states, params = _read_parameters(node, 1, 14)
-    return 'poly_brown', {'F': states[0], 'p': params}
+    return 'poly_brown', {'F': states[0], 'p': params}, ['F', 'p']
 
 
 @_register(
@@ -137,7 +137,7 @@ def fisheye_10_5_5_data_reader(node, i):
         'P': params[12:14],
         'l': params[22:24],
         }
-    return types[i], parameters
+    return types[i], parameters, ['F', 'C', 'R', 'P', 'l']
 
 
 @_register('ModRad')
@@ -150,7 +150,7 @@ def rad_data_reader(node, i=0):
     R = xmlutil.children_float(node, 'CoeffDist')
     C = xmlutil.child_floats_split(node, 'CDist')
     type_ = 'poly_radial_{}'.format(1+2*len(R))
-    return type_, {'C': C, 'R': R}
+    return type_, {'C': C, 'R': R}, ['C', 'R']
 
 
 @_register('ModPhgrStd')
@@ -160,8 +160,9 @@ def phgr_std_data_reader(node, i=0):
 
     :param node: the ``ModPhgrStd`` XML node.
     """
-    type_, parameters = rad_data_reader(
+    type_, parameters, func_signature = rad_data_reader(
         xmlutil.child(node, 'RadialePart'))
     parameters['P'] = xmlutil.child_floats(node, '[P1,P2]', 0)
     parameters['b'] = xmlutil.child_floats(node, '[b1,b2]', 0)
-    return type_+'_Pb', parameters
+    func_signature.extend(['P', 'b'])
+    return type_+'_Pb', parameters, func_signature

--- a/cli_li3ds/import_autocal.py
+++ b/cli_li3ds/import_autocal.py
@@ -215,6 +215,7 @@ def transfo_pinhole(source, target, transfo, node):
         source, target, transfo,
         name='{name}#projection'.format(**transfo),
         type_name='projective_pinhole',
+        func_signature=['focal', 'ppa'],
         parameters=[{
             'focal': xmlutil.child_float(node, 'F'),
             'ppa': xmlutil.child_floats_split(node, 'PP'),
@@ -231,16 +232,18 @@ def transfo_orintglob(source, target, transfo, node):
         source, target, transfo,
         name='{name}#orintglob'.format(**transfo),
         type_name='affine_mat3x2',
+        func_signature=['mat3x2'],
         parameters=[{'mat3x2': [u[0], v[0], p[0], u[1], v[1], p[1]]}],
         reverse=xmlutil.child_bool(node, 'C2M'),
     )
 
 
 def transfo_distortion(source, target, transfo, node, i):
-    transfo_type, parameters = distortion.read_info(node)
+    transfo_type, parameters, func_signature = distortion.read_info(node)
     return api.Transfo(
         source, target, transfo,
         name='{name}#distortion[{i}]'.format(i=i, **transfo),
         type_name=transfo_type,
+        func_signature=func_signature,
         parameters=[parameters],
     )

--- a/cli_li3ds/import_ept.py
+++ b/cli_li3ds/import_ept.py
@@ -160,7 +160,8 @@ class ImportEpt(Command):
         objs.add(datasource)
 
         transfo = api.Transfo(referential_spherical, referential_cartesian, transfo,
-                              type_name='spherical_to_cartesian', parameters=[])
+                              type_name='spherical_to_cartesian', parameters=[],
+                              func_signature=[])
         transfotree = api.Transfotree([transfo], sensor, transfotree)
         objs.add(transfotree)
 

--- a/cli_li3ds/import_extcalib.py
+++ b/cli_li3ds/import_extcalib.py
@@ -172,6 +172,7 @@ def transfo_grp(source, target, transfo, matrix):
     return api.Transfo(
         source, target, transfo,
         type_name='affine_mat4x3',
+        func_signature=['mat4x3'],
         parameters=[{'mat4x3': matrix}],
     )
 

--- a/cli_li3ds/import_ori.py
+++ b/cli_li3ds/import_ori.py
@@ -135,6 +135,7 @@ def transfo_pose(source, target, transfo, node):
         source, target, transfo,
         name='{name}#Externe'.format(**transfo),
         type_name='affine_mat4x3',
+        func_signature=['mat4x3'],
         parameters=[{'mat4x3': matrix}],
     )
 
@@ -147,5 +148,6 @@ def transfo_orint(source, target, transfo, node):
         source, target, transfo,
         name='{name}#OrIntImaM2C'.format(**transfo),
         type_name='affine_mat3x2',
+        func_signature=['mat3x2'],
         parameters=[{'mat3x2': [u[0], v[0], p[0], u[1], v[1], p[1]]}],
     )

--- a/cli_li3ds/import_orimatis.py
+++ b/cli_li3ds/import_orimatis.py
@@ -363,6 +363,7 @@ def transfo_pinh(source, target, transfo, root):
         source, target, transfo,
         name='{name}#projection'.format(**transfo),
         type_name='projective_pinhole',
+        func_signature=['focal', 'ppa'],
         parameters=[{
             'focal': xmlutil.child_float(node, 'ppa/focale'),
             'ppa': xmlutil.child_floats(node, 'ppa/[c,l]'),
@@ -376,6 +377,7 @@ def transfo_sphe(source, target, transfo, root):
         source, target, transfo,
         name='{name}#projection'.format(**transfo),
         type_name='cartesian_to_spherical',
+        func_signature=['ppa', 'lambda', 'phi'],
         parameters=[{
             'ppa': xmlutil.child_floats(node, 'ppa/[c,l]'),
             'lambda': xmlutil.child_floats(node, 'frame/lambda_[min,max]'),
@@ -390,6 +392,7 @@ def transfo_dist(source, target, transfo, root):
         source, target, transfo,
         name='{name}#distortion'.format(**transfo),
         type_name='poly_radial_7',
+        func_signature=['C', 'R'],
         parameters=[{
             'C': xmlutil.child_floats(node, 'distortion/pps/[c,l]'),
             'R': xmlutil.child_floats(node, 'distortion/[r3,r5,r7]'),
@@ -409,6 +412,7 @@ def transfo_quat(source, target, transfo, acquisition, root):
         source, target, transfo,
         name='{name}#quaternion'.format(**transfo),
         type_name='affine_quat',
+        func_signature=['quat', 'vec3', '_time'],
         parameters=[{'quat': quat, 'vec3': p, '_time': acquisition}],
         reverse=reverse,
     )
@@ -437,6 +441,7 @@ def transfo_matr(source, target, transfo, acquisition, root):
         source, target, transfo,
         name='{name}#mat3d'.format(**transfo),
         type_name='affine_mat4x3',
+        func_signature=['mat4x3', '_time'],
         parameters=[{'mat4x3': matrix, '_time': acquisition}],
         reverse=reverse,
     )

--- a/cli_li3ds/import_sbet.py
+++ b/cli_li3ds/import_sbet.py
@@ -227,4 +227,5 @@ class ImportSbet(Command):
             vec3 = ['x', 'y', 'z']
         return api.Transfo(source, target, transfo,
                            type_name='affine_quat',
+                           func_signature=['quat', 'vec3', '_time'],
                            parameters=[{'quat': quat, 'vec3': vec3, '_time': 'time'}])

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -23,7 +23,8 @@ def transfo(scope='module'):
     sensor = api.Sensor(name='sensor')
     source = api.Referential(name='source', sensor=sensor)
     target = api.Referential(name='target', sensor=sensor)
-    return api.Transfo(name='transfo', source=source, target=target)
+    return api.Transfo(name='transfo', source=source, target=target,
+                       type_name='transfo_type', func_signature=[], parameters=[])
 
 
 def test_apiobj(apiobj):
@@ -57,14 +58,16 @@ def test_eq_complex():
     sen1 = api.Sensor(name='sen')
     src1 = api.Referential(name='src', sensor=sen1)
     tgt1 = api.Referential(name='dst', sensor=sen1)
-    tra1 = api.Transfo(name='tra', source=src1, target=tgt1)
+    tra1 = api.Transfo(name='tra', source=src1, target=tgt1,
+                       type_name='transfo_type', func_signature=[], parameters=[])
     ttr1 = api.Transfotree(transfos=[tra1], name='ttr')
 
     # create transfo tree 2
     sen2 = api.Sensor(name='sen')
     src2 = api.Referential(name='src', sensor=sen2)
     tgt2 = api.Referential(name='dst', sensor=sen2)
-    tra2 = api.Transfo(name='tra', source=src2, target=tgt2)
+    tra2 = api.Transfo(name='tra', source=src2, target=tgt2,
+                       type_name='transfo_type', func_signature=[], parameters=[])
     ttr2 = api.Transfotree(transfos=[tra2], name='ttr')
 
     assert ttr1 == ttr2


### PR DESCRIPTION
In a transfo type func_signature defines the order into which arguments are to be passed to the transform function. So the ordering should not be alphabetical. It is fixed and specific to each transform function.