### PR TITLE
import-image: change gps/unix time conversion

### DIFF
--- a/cli_li3ds/import_image.py
+++ b/cli_li3ds/import_image.py
@@ -163,9 +163,9 @@ class ImportImage(Command):
             image_objs = json.load(f)
         for image_obj in image_objs:
             # image_obj['date'] is the number of seconds since January 5, 1980 (GPS time
-            # reference) minus 1e9. So we add 1e9 and 315964782 to get the number of
+            # reference) minus 1e9. So we add 1e9 and 315964800 to get the number of
             # seconds since January 1, 1970.
-            dt = datetime.datetime.fromtimestamp(image_obj['date'] + 1e9 + 315964782, tz=pytz.UTC)
+            dt = datetime.datetime.fromtimestamp(image_obj['date'] + 1e9 + 315964800, tz=pytz.UTC)
             cls.image_date_cache[image_obj['id']] = dt
         assert(image_id_no_cam in cls.image_date_cache)
         return cls.image_date_cache[image_id_no_cam]


### PR DESCRIPTION
This changes the conversion from gps to unix time. Now we use 315964800 as the offset between unix and gps, which does not take leap seconds into account. This is to be consistent with what's done on the API side for trajectories.