### PR TITLE
import-ept: calculate time offset

### DIFF
--- a/cli_li3ds/foreignpc.py
+++ b/cli_li3ds/foreignpc.py
@@ -6,8 +6,10 @@ def create_foreignpc_table(foreignpc_table, foreignpc_server, driver):
     del foreignpc_table['schema']
     del foreignpc_table['table']
 
-    options = {'patch_size': 100, 'time_offset': foreignpc_table['time_offset']}
-    del foreignpc_table['time_offset']
+    options = {'patch_size': 100}
+    if 'time_offset' in foreignpc_table:
+        options['time_offset'] = foreignpc_table['time_offset']
+        del foreignpc_table['time_offset']
 
     if driver == 'fdwli3ds.Sbet':
         options['sources'] = foreignpc_table['filepath']

--- a/cli_li3ds/import_ept.py
+++ b/cli_li3ds/import_ept.py
@@ -101,6 +101,7 @@ class ImportEpt(Command):
         foreignpc_table = {
             'table': '{table}',
             'filepath': '{filepath}',
+            'time_offset': cls.time_offset_from_session_time(session_time),
         }
         foreignpc_view = {
             'view': '{table}_view',
@@ -177,3 +178,12 @@ class ImportEpt(Command):
         session_time = pytz.UTC.localize(session_time)
         section_name = parts[2]
         return name, session_time, section_name
+
+    @staticmethod
+    def time_offset_from_session_time(session_time):
+        # the time reference for time values in the EPT file is the beginning of the
+        # session day. So the time offset is the session day converted to the POSIX
+        # timestamp
+        dt = datetime.datetime(session_time.year, session_time.month, session_time.day,
+                               tzinfo=pytz.UTC)
+        return dt.timestamp()

--- a/cli_li3ds/import_ept.py
+++ b/cli_li3ds/import_ept.py
@@ -47,10 +47,6 @@ class ImportEpt(Command):
             type=int, default=0,
             help='SRID of lidar coordinates (optional, default is 0)')
         parser.add_argument(
-            '--time-offset', '-x',
-            type=float, default=0,
-            help='time offset in seconds (optional, default is 0)')
-        parser.add_argument(
             'directory',
             type=pathlib.Path,
             help='directory containing ept files')
@@ -64,7 +60,6 @@ class ImportEpt(Command):
             'foreignpc/table': {
                 'schema': parsed_args.database_schema,
                 'srid': parsed_args.srid,
-                'time_offset': parsed_args.time_offset,
             },
             'foreignpc/server': {
                 'name': parsed_args.server_name,

--- a/cli_li3ds/import_sbet.py
+++ b/cli_li3ds/import_sbet.py
@@ -53,10 +53,6 @@ class ImportSbet(Command):
             help='SRID of output trajectories (in the li3ds datastore) '
                  '(optional, default is 2154)')
         parser.add_argument(
-            '--time-offset', '-x',
-            type=float, default=0,
-            help='time offset in seconds (optional, default is 0)')
-        parser.add_argument(
             'filename', nargs='+',
             help='sbet file names, may be Unix-style patterns (e.g. *.sbet)')
         return parser
@@ -69,7 +65,6 @@ class ImportSbet(Command):
             'foreignpc/table': {
                 'schema': parsed_args.database_schema,
                 'srid': parsed_args.srid_input,
-                'time_offset': parsed_args.time_offset,
             },
             'foreignpc/server': {
                 'name': parsed_args.server_name,


### PR DESCRIPTION
In import-ept determine the time offset that should be used to interpret the time values in EPT files, and send it to foreignpc/table as a table option.