### PR TITLE
Change the ins2cam and cam2ins

### DIFF
--- a/cli_li3ds/import_platform.py
+++ b/cli_li3ds/import_platform.py
@@ -70,7 +70,7 @@ class ImportPlatform(Command):
             name='ins2cam',
             transfo_type=affine_mat4x3,
             parameters=[
-                {'mat4x3': [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]}
+                {'mat4x3': [-1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0]}
             ])
 
         transfo_camera_group2ins = api.Transfo(
@@ -79,7 +79,7 @@ class ImportPlatform(Command):
             name='cam2ins',
             transfo_type=affine_mat4x3,
             parameters=[
-                {'mat4x3': [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]}
+                {'mat4x3': [-1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0]}
             ])
 
         affine_quat = api.TransfoType(


### PR DESCRIPTION
Change the ins2cam and cam2ins matrices, as it looks like a rotation by &#960; around Z is required to go from the camera base to the INS, and vice-versa. This is for Stereopolis.

I am going to merge this because it does fix things for us, but this is to be discussed with @mbredif. 


